### PR TITLE
Update build.gradle changed kotlin version to 1.5.20 from 1.3.50

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.
The following dependencies do not satisfy the required version:
project ':add_to_wallet' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50
Getting this error